### PR TITLE
Support Amazon SQS as a message broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.7
 MAINTAINER Hypothes.is Project and contributors
 
 # Install system and runtime dependencies.
-RUN apk add --no-cache python2 py2-pip
+RUN apk add --no-cache libcurl python2 py2-pip
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/h-periodic hypothesis
@@ -12,7 +12,11 @@ COPY README.rst requirements.txt supervisord.conf start.sh hperiodic.py healthch
 
 # Install build deps, build then clean up.
 RUN apk add --no-cache --virtual build-deps \
+    build-base \
     git \
+    curl-dev \
+    openssl-dev \
+    python-dev \
     && pip install --no-cache-dir -U pip supervisor \
     && pip install --no-cache-dir -r requirements.txt \
     && apk del build-deps

--- a/hperiodic.py
+++ b/hperiodic.py
@@ -7,11 +7,31 @@ Celery configuration for a separate beat process.
 from __future__ import absolute_import
 
 from datetime import timedelta
+import os
 
 from celery import Celery
 
+# This can be imported on any system but properties and methods can only be
+# accessed when running on an actual EC2 instance.
+from ec2_metadata import ec2_metadata
+
+# Configure the broker transport. These settings need to match the
+# configuration of the Celery worker in 'h' which will actually execute the
+# tasks.
+broker_url = os.getenv('BROKER_URL','')
+broker_transport_options = {}
+if broker_url.startswith('sqs://'):
+    broker_transport_options = {
+        # Use SQS from the same region as the EC2 instance on which h-periodic
+        # is running.
+        'region': ec2_metadata.region,
+        # Use the same Celery queue name prefix that 'h' uses.
+        'queue_name_prefix': 'hypothesis-h-',
+    }
+
 celery = Celery('h')
 celery.conf.update(
+    broker_transport_options=broker_transport_options,
     beat_schedule={
         'purge-deleted-annotations': {
             'task': 'h.tasks.cleanup.purge_deleted_annotations',

--- a/hperiodic.py
+++ b/hperiodic.py
@@ -21,12 +21,21 @@ from ec2_metadata import ec2_metadata
 broker_url = os.getenv('BROKER_URL','')
 broker_transport_options = {}
 if broker_url.startswith('sqs://'):
+    # Prefix for SQS queue names to make it clearer which service the queues
+    # are associated with.
+    #
+    # This is configurable to support different h instances in the same AWS
+    # account.
+    #
+    # This prefix must match the one used for the corresponding h instance.
+    queue_name_prefix = os.getenv('SQS_QUEUE_NAME_PREFIX', 'hypothesis-h-')
+
     broker_transport_options = {
+        'queue_name_prefix': queue_name_prefix,
+
         # Use SQS from the same region as the EC2 instance on which h-periodic
         # is running.
         'region': ec2_metadata.region,
-        # Use the same Celery queue name prefix that 'h' uses.
-        'queue_name_prefix': 'hypothesis-h-',
     }
 
 celery = Celery('h')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+boto3  # for SQS (not using celery[sqs] because it uses wrong boto version)
 celery == 4.1.0
+ec2-metadata
+pycurl  # for SQS
 Flask


### PR DESCRIPTION
This is a counterpart to https://github.com/hypothesis/h/pull/5035 which enables the use of Amazon SQS rather than RabbitMQ as the message broker for running periodic tasks in h.

The SQS configuration (queue names, region name) needs to match the configuration in `h/celery.py` when h is using SQS.