### PR TITLE
Update Alpine and Celery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM gliderlabs/alpine:3.4
+FROM alpine:3.7
 MAINTAINER Hypothes.is Project and contributors
 
-RUN apk-install \
-    git \
-    python \
-    py-pip \
-    && pip install --no-cache-dir -U pip supervisor
+# Install system and runtime dependencies.
+RUN apk add --no-cache python2 py2-pip
 
 # Create the hypothesis user, group, home directory and package directory.
 RUN addgroup -S hypothesis && adduser -S -G hypothesis -h /var/lib/h-periodic hypothesis
@@ -13,7 +10,12 @@ WORKDIR /var/lib/h-periodic
 
 COPY README.rst requirements.txt supervisord.conf start.sh hperiodic.py healthcheck.py ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+# Install build deps, build then clean up.
+RUN apk add --no-cache --virtual build-deps \
+    git \
+    && pip install --no-cache-dir -U pip supervisor \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del build-deps
 
 EXPOSE 8080
 USER hypothesis

--- a/hperiodic.py
+++ b/hperiodic.py
@@ -12,7 +12,7 @@ from celery import Celery
 
 celery = Celery('h')
 celery.conf.update(
-    CELERYBEAT_SCHEDULE={
+    beat_schedule={
         'purge-deleted-annotations': {
             'task': 'h.tasks.cleanup.purge_deleted_annotations',
             'schedule': timedelta(hours=1)
@@ -34,5 +34,5 @@ celery.conf.update(
             'schedule': timedelta(hours=6)
         },
     },
-    CELERY_TASK_SERIALIZER='json',
+    task_serializer='json',
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-celery == 3.1.25  # Pin to latest 3.1.x to ensure forwards-compat with 4.x
+celery == 4.1.0
 Flask


### PR DESCRIPTION
This PR is a prerequisite to adding SQS support extracted from https://github.com/hypothesis/h-periodic/pull/8. It upgrades the Alpine Linux base image and Celery to the same versions used in h. Additionally I have refactored the Docker image to use the same pattern as h's Dockerfile to avoid leaving built-time only dependencies in the final image.

----

To test this PR, or any for this project, manually:

1. Edit `hperiodic.py` and shorten the schedule for one of the tasks down to a few seconds
2. Build a Docker image with `docker build -t {some tag} .`
3. Run the Docker container `docker run -it -e 'BROKER_URL=amqp://guest:guest@rabbitmq:5672//' --link rabbitmq {tag name}`
4. Run the h dev server
5. Check that every few seconds (whatever schedule was set in step 1) the h dev server prints a message indicating that it is running that task.