### PR TITLE
Expire periodic tasks so they don't pile up

### DIFF
--- a/h_periodic/beat.py
+++ b/h_periodic/beat.py
@@ -8,26 +8,32 @@ celery = Celery("h")
 celery.conf.update(
     beat_schedule={
         "purge-deleted-annotations": {
+            "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_deleted_annotations",
             "schedule": timedelta(hours=1),
         },
         "purge-expired-authtickets": {
+            "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_expired_auth_tickets",
             "schedule": timedelta(hours=1),
         },
         "purge-expired-authzcodes": {
+            "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_expired_authz_codes",
             "schedule": timedelta(hours=1),
         },
         "purge-expired-tokens": {
+            "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_expired_tokens",
             "schedule": timedelta(hours=1),
         },
         "purge-removed-features": {
+            "options": {"expires": 5400},
             "task": "h.tasks.cleanup.purge_removed_features",
             "schedule": timedelta(hours=6),
         },
         "sync-annotations": {
+            "options": {"expires": 30},
             "task": "h.tasks.indexer.sync_annotations",
             "schedule": timedelta(minutes=1),
             "kwargs": {"limit": 10000},


### PR DESCRIPTION
If h's Celery workers had an outage then h-periodic would continue
piling up instances of each periodic task in Rabbit. For example one
`"sync-annotations"` task every minute while h was down. When the
workers came back up they would process all of the queued periodic tasks
at once, as fast as they could. So you'd get lots of
`"sync-annotations"` tasks being run at once by all the workers.
Potentially thrashing the system.

Change the periodic tasks to expire after a few seconds if not taken by
a worker. After an h outage, each task will get processed again the next
time it's scheduled after the workers come back, rather than piling up
many instances of each task on the queue.

I couldn't see a way to do this without having to repeat the options for
each task. I tried changing it to have an `on_after_configure.connect`
listener that calls `add_periodic_task()` (see
https://docs.celeryproject.org/en/stable/userguide/periodic-tasks.html#entries)
but it didn't seem to work.