### PR TITLE
Jenkinsfile Update - Removed qa deploy milestone.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,6 @@ node {
 
 onlyOnMaster {
     milestone()
-    stage("qa deploy") {
-        deployApp(image: img, app: "h-periodic", env: "qa")
-    }
-
-    milestone()
     stage("prod deploy") {
         input(message: "Deploy to prod?")
         milestone()


### PR DESCRIPTION
This branch removes the ability to perform a QA deploy for h-periodic. The `qa milestone` has been removed from the Jenkinsfile.