### PR TITLE
Add checkmate beat and include it in the status page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,9 @@
 *.pyc
 .coverage
 .coverage.*
-celerybeat-schedule
-celerybeat-schedule.*
-celerybeat.pid
+h-celerybeat-schedule
+h-celerybeat-schedule.*
+h-celerybeat.pid
 checkmate-celerybeat-schedule
 checkmate-celerybeat-schedule.*
 checkmate-celerybeat.pid

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@
 celerybeat-schedule
 celerybeat-schedule.*
 celerybeat.pid
+checkmate-celerybeat-schedule
+checkmate-celerybeat-schedule.*
+checkmate-celerybeat.pid
 supervisord.log

--- a/README.markdown
+++ b/README.markdown
@@ -53,5 +53,5 @@ linting, code formatting, etc.
 
 | Environment variable | Usage | Example |
 |----------------------|-------|---------|
-| `BROKER_URL`           | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
+| `H_BROKER_URL`         | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
 | `CHECKMATE_BROKER_URL` | The `checkmate` AMPQ broker | `amqp://user:password@rabbit.example.com:5673//` |  

--- a/README.markdown
+++ b/README.markdown
@@ -48,3 +48,10 @@ This will:
 **That's it!** You’ve finished setting up your h-periodic development
 environment. Run `make help` to see all the commands that're available for
 linting, code formatting, etc.
+
+### Configuration
+
+| Environment variable | Usage | Example |
+|----------------------|-------|---------|
+| `BROKER_URL`           | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
+| `CHECKMATE_BROKER_URL` | The `checkmate` AMPQ broker | `amqp://user:password@rabbit.example.com:5673//` |  

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -11,7 +11,14 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:h-beat]
-command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat
+command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=celerybeat.pid
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
+[program:checkmate-beat]
+command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -11,7 +11,7 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:h-beat]
-command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=celerybeat.pid
+command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,11 +12,18 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:h-beat]
-command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat
+command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=celerybeat.pid
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
+
+[program:checkmate-beat]
+command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
 
 [eventlistener:logger]
 command=bin/logger

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,7 +12,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:h-beat]
-command=celery -b %(ENV_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=celerybeat.pid
+command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true

--- a/h_periodic/checkmate_beat.py
+++ b/h_periodic/checkmate_beat.py
@@ -1,0 +1,17 @@
+"""Celery beat scheduler process configuration."""
+from datetime import timedelta
+
+from celery import Celery
+
+celery = Celery("checkmate")
+celery.conf.update(
+    beat_schedule_filename="checkmate-celerybeat-schedule",
+    beat_schedule={
+        "sync-blocklist": {
+            "options": {"expires": 30},
+            "task": "checkmate.async.tasks.sync_blocklist",
+            "schedule": timedelta(minutes=1),
+        },
+    },
+    task_serializer="json",
+)

--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -6,6 +6,7 @@ from celery import Celery
 
 celery = Celery("h")
 celery.conf.update(
+    beat_schedule_filename="h-celerybeat-schedule",
     beat_schedule={
         "purge-deleted-annotations": {
             "options": {"expires": 1800},

--- a/h_periodic/views/status.py
+++ b/h_periodic/views/status.py
@@ -8,8 +8,8 @@ from pyramid.view import view_config
 
 
 class StatusView:
-    H_PID_FILE = "celerybeat.pid"
-    H_BROKER_VAR = "BROKER_URL"
+    H_PID_FILE = "h-celerybeat.pid"
+    H_BROKER_VAR = "H_BROKER_URL"
     CHECKMATE_PID_FILE = "checkmate-celerybeat.pid"
     CHECKMATE_BROKER_VAR = "CHECKMATE_BROKER_URL"
 

--- a/tests/unit/h_periodic/test_app.py
+++ b/tests/unit/h_periodic/test_app.py
@@ -1,0 +1,4 @@
+# pylint: disable=unused-import
+# This is for some dodgy test coverage
+
+from h_periodic.app import create_app

--- a/tests/unit/h_periodic/test_checkmate_beat.py
+++ b/tests/unit/h_periodic/test_checkmate_beat.py
@@ -1,0 +1,4 @@
+# pylint: disable=unused-import
+# This is for some dodgy test coverage
+
+from h_periodic.checkmate_beat import celery

--- a/tests/unit/h_periodic/test_h_beat.py
+++ b/tests/unit/h_periodic/test_h_beat.py
@@ -1,0 +1,4 @@
+# pylint: disable=unused-import
+# This is for some dodgy test coverage
+
+from h_periodic.h_beat import celery

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
 setenv =
     PYTHONUNBUFFERED = 1
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
-    BROKER_URL = amqp://guest:guest@localhost:5672//
+    H_BROKER_URL = amqp://guest:guest@localhost:5672//
     CHECKMATE_BROKER_URL = amqp://guest:guest@localhost:5673//
 commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ setenv =
     PYTHONUNBUFFERED = 1
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     BROKER_URL = amqp://guest:guest@localhost:5672//
+    CHECKMATE_BROKER_URL = amqp://guest:guest@localhost:5673//
 commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     lint: pylint h_periodic


### PR DESCRIPTION
Needs to be rebased on top of:

 * https://github.com/hypothesis/h-periodic/tree/separate-status-reporting
 * https://github.com/hypothesis/h-periodic/tree/separate-h-beat

This PR:

 * Adds a new beat for Checkmate
 * Includes the status in the status page
 * Will report as:
    * 200 - "ok" if both are up
    * 200 - "degraded" if one is down
    * 500 - "down" if both are down
 * Expands linting and formatting to the tests
 * Gets 100% coverage by including and "no cover"-ing files

### Review notes

 * AWS doesn't care what content we send, so "degraded" and "ok" are basically the same
 * Ian says we can script it to parse and understand it if we want to

### Testing notes

To test the status page:

 * Setup and take down the services in `h` and `checkmate` and observe the changes
 * Comment in and out the various beats and see the changes

To test the running against Checkmate:

 * Run `docker stop checkmate_postgres_1;docker rm checkmate_postgres_1`
 * In `checkmate` run: `git checkout use-celery-to-update-db` (if it's not been merged already)
 * In `checkmate` run: `make services`
 * In `checkmate` run: `CHECKMATE_BLOCKLIST_URL=<s3_url> make dev`
 * In `h-periodic` run `rm *celerybeat*`
 * You should see checkmate update as a result of running the beat
