### PR TITLE
Fix checkmate celery queue to match the settings in Checkmate

### DIFF
--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -11,14 +11,14 @@ stopsignal = KILL
 stopasgroup = true
 
 [program:h-beat]
-command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid
+command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid --loglevel INFO
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
 [program:checkmate-beat]
-command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid
+command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid --loglevel INFO
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -12,14 +12,14 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:h-beat]
-command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid
+command=celery -b %(ENV_H_BROKER_URL)s -A h_periodic.h_beat beat --pidfile=h-celerybeat.pid --loglevel INFO
 stdout_logfile=NONE
 stderr_logfile=NONE
 stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:checkmate-beat]
-command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid
+command=celery -b %(ENV_CHECKMATE_BROKER_URL)s -A h_periodic.checkmate_beat beat --pidfile=checkmate-celerybeat.pid --loglevel INFO
 stdout_events_enabled=true
 stderr_events_enabled=true
 stopsignal = KILL

--- a/h_periodic/checkmate_beat.py
+++ b/h_periodic/checkmate_beat.py
@@ -2,9 +2,19 @@
 from datetime import timedelta
 
 from celery import Celery
+from kombu import Exchange, Queue
 
 celery = Celery("checkmate")
 celery.conf.update(
+    task_queues=[
+        Queue(
+            "celery",
+            # We don't care if the messages are lost if the broker restarts
+            durable=False,
+            routing_key="celery",
+            exchange=Exchange("celery", type="direct", durable=False),
+        ),
+    ],
     beat_schedule_filename="checkmate-celerybeat-schedule",
     beat_schedule={
         "sync-blocklist": {


### PR DESCRIPTION
The `h` beat works by happening to line up with the default, but checkmate is different, so it doesn't work.

### Testing notes

* In Checkmate run `make services dev`
* Run `make dev`
* See that tasks are being queued
* In Checkmate see nothing ~(WHY?) - This is actually doing what it should, if you make the task touch a file, you can see it's touched, but no log output comes out anymore. What's changed?~ - Fixed in https://github.com/hypothesis/checkmate/pull/47