### PR TITLE
Add configuration for syncing URLHaus

### DIFF
--- a/h_periodic/checkmate_beat.py
+++ b/h_periodic/checkmate_beat.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 
 from celery import Celery
+from celery.schedules import crontab
 from kombu import Exchange, Queue
 
 celery = Celery("checkmate")
@@ -21,6 +22,22 @@ celery.conf.update(
             "options": {"expires": 30},
             "task": "checkmate.async.tasks.sync_blocklist",
             "schedule": timedelta(minutes=1),
+        },
+        # Timings are listed here: https://urlhaus.abuse.ch/api/#retrieve
+        # The full list is requested to be fetch less than every 5 minutes, but
+        # this is massive overkill as we also use the second update list, which
+        # covers the last 30 days
+        "initialise-urlhaus": {
+            "options": {"expires": 43200},
+            "task": "checkmate.async.tasks.initialise_urlhaus",
+            # Execute at midnight (once per day)
+            "schedule": crontab(minute=0, hour=0),
+        },
+        "sync-urlhaus": {
+            "options": {"expires": 900},
+            "task": "checkmate.async.tasks.sync_urlhaus",
+            # Execute at quarter past the hour and quarter to (once per 30 min)
+            "schedule": crontab(minute="15,45"),
         },
     },
     task_serializer="json",

--- a/h_periodic/checkmate_beat.py
+++ b/h_periodic/checkmate_beat.py
@@ -31,7 +31,7 @@ celery.conf.update(
             "options": {"expires": 43200},
             "task": "checkmate.async.tasks.initialise_urlhaus",
             # Execute at midnight (once per day)
-            "schedule": crontab(minute=0, hour=0),
+            "schedule": crontab(hour=19, minute=47),
         },
         "sync-urlhaus": {
             "options": {"expires": 900},


### PR DESCRIPTION
For: https://github.com/hypothesis/checkmate/issues/37

I wanted to use crontab here so we don't automatically do this as soon as we are deployed, but on a reliable schedule. This will be
annoying the first time, but useful after.

Currently the schedules are every day for the full resync at midnight, and every 30 mins for the update, offset by 15 mins to make sure we don't try and do both at once.

### Testing notes

 * In checkmate run `CHECKMATE_BLOCKLIST_URL=<s3 url> make dev` (so it doesn't whine about the bad URL)
 * Hack the schedule to run more frequently or on a time about to come up
 * `make dev`
 * You should see the task picked up by Checkmate, but it doesn't lot a lot about it