### PR TITLE
Add DISABLE_H_BEAT envvar

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -51,3 +51,4 @@ linting, code formatting, etc.
 |----------------------|-------|---------|
 | `H_BROKER_URL`         | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
 | `CHECKMATE_BROKER_URL` | The `checkmate` AMPQ broker | `amqp://user:password@rabbit.example.com:5673//` |
+| `DISABLE_H_BEAT` | Whether to disable the `h_beat` process | `true` to disable the `h_beat` process, `false` to leave it enabled. Defaults to `false` (leave it enabled) |

--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -1,8 +1,24 @@
 """Celery beat scheduler process configuration."""
 
+import sys
 from datetime import timedelta
+from os import environ
 
 from celery import Celery
+
+
+def asbool(value):
+    """Return True if value is any of "t", "true", "y", etc (case-insensitive)."""
+    return str(value).strip().lower() in ("t", "true", "y", "yes", "on", "1")
+
+
+# We don't want periodic tasks for h-qa because h-qa and h-prod share the same
+# database and search index.
+# See https://github.com/hypothesis/playbook/issues/436
+# So we'll set this DISABLE_H_BEAT envvar on h-qa.
+if asbool(environ.get("DISABLE_H_BEAT")):  # pragma: nocover
+    print("h_beat disabled by DISABLE_H_BEAT environment variable")
+    sys.exit()
 
 celery = Celery("h")
 celery.conf.update(

--- a/tests/unit/h_periodic/h_beat_test.py
+++ b/tests/unit/h_periodic/h_beat_test.py
@@ -1,4 +1,36 @@
-# pylint: disable=unused-import
-# This is for some dodgy test coverage
+import pytest
 
-from h_periodic.h_beat import celery
+from h_periodic.h_beat import asbool
+
+
+@pytest.mark.parametrize("uppercase", [True, False])
+@pytest.mark.parametrize("prefix", ["", " ", "   "])
+@pytest.mark.parametrize("suffix", ["", " ", "   "])
+@pytest.mark.parametrize(
+    "s,expected_output",
+    [
+        ("t", True),
+        ("true", True),
+        ("y", True),
+        ("yes", True),
+        ("on", True),
+        ("1", True),
+        ("", False),
+        ("f", False),
+        ("false", False),
+        ("n", False),
+        ("no", False),
+        ("off", False),
+        ("0", False),
+    ],
+)
+def test_asbool(s, expected_output, uppercase, prefix, suffix):
+    if uppercase:
+        s = s.upper()
+    s = prefix + s + suffix
+
+    assert asbool(s) == expected_output
+
+
+def test_asbool_returns_falsey_for_None():
+    assert not asbool(None)

--- a/tests/unit/h_periodic/sanity_test.py
+++ b/tests/unit/h_periodic/sanity_test.py
@@ -1,3 +1,0 @@
-def test_sanity():
-    # A single test which passes to make pytest happy
-    assert True

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ passenv =
     HOME
     {tests,functests}: PYTEST_ADDOPTS
     dev: DEBUG
+    dev: DISABLE_H_BEAT
 deps =
     dev: -e .
     dev: -r requirements/dev.txt


### PR DESCRIPTION
Depends on https://github.com/hypothesis/h-periodic/pull/49

We [don't want h-periodic for h-qa](https://github.com/hypothesis/playbook/issues/436).

Unfortunately we can't just get rid of h-periodic-qa entirely as previously planned, because we *do* want h-periodic for checkmate-qa.

I don't think just removing the `BROKER_URL` envvar from h-qa will work. h's code isn't really designed to disable Celery workers if there's no `BROKER_URL`. Rather, it assumes that you do want Celery workers and uses a default broker URL if none is set: https://github.com/hypothesis/h/blob/36a266b1d5ddbb7bd00fd888766c391f3a3da810/h/celery.py#L24-L27

Also, what would happen if h-periodic-qa was still emitting periodic tasks for h-qa workers to consume, but h-qa wasn't running any connected workers? I think this might cause a pile up of unacknowledged jobs on RabbitMQ (or it might not, if the jobs expire). And I think it might trigger a worker connections low watermark alarm in RabbitMQ / CloudAMQP.

Besides, we *do* actually want h-qa's workers to be connected and consuming non-periodic Celery tasks emitted by h-qa itself.

I don't think just removing the `H_BROKER_URL` envvar from h-periodic-qa will work either. This will just cause h-periodic-qa's supervisor to crash because it assumes that this envvar exists: https://github.com/hypothesis/h-periodic/blob/9e85310218f53fe8fa652b25111327d23b5b948b/conf/supervisord.conf#L15

h-periodic's Python code in `h_beat.py` is also coded to assume that the envvar exists and the beat is wanted.

Instead, add logic to `h_beat.py` so that it exits if a `DISABLE_H_BEAT` envvar is set.

This rests on the hope that h-qa and h-prod use different Celery queues so that tasks generated for h-prod (both by h itself and by h-periodic) will only be consumed by h-prod's Celery workers not h-qa's. We'll have to deploy this to test that for sure.

I've resisted the urge to implement any kind of generic `DISABLE_*_BEAT` or `ENABLE_*_BEAT` envvars support. The fact that we don't want periodic tasks for h-qa is unique to h (it's due to h prod and qa sharing the same DB and search index). So let's just keep this simple.