### PR TITLE
Replace `tox-pip-extensions` with `tox-pip-sync`

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,15 +16,13 @@ billiard==3.6.3.0
     #   celery
 celery==4.4.7
     # via -r requirements/requirements.txt
-decorator==4.4.2
-    # via
-    #   ipython
-    #   traitlets
+decorator==5.0.7
+    # via ipython
 ipython-genutils==0.2.0
     # via traitlets
 ipython==7.23.0
     # via -r requirements/dev.in
-jedi==0.17.2
+jedi==0.18.0
     # via ipython
 kombu==4.6.11
     # via
@@ -32,27 +30,25 @@ kombu==4.6.11
     #   celery
 matplotlib-inline==0.1.2
     # via ipython
-parso==0.7.1
+parso==0.8.2
     # via jedi
 pexpect==4.8.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
-prompt-toolkit==3.0.8
+prompt-toolkit==3.0.18
     # via ipython
-ptyprocess==0.6.0
+ptyprocess==0.7.0
     # via pexpect
-pygments==2.7.4
+pygments==2.9.0
     # via ipython
 pytz==2020.1
     # via
     #   -r requirements/requirements.txt
     #   celery
-six==1.15.0
-    # via traitlets
 supervisor==4.2.2
     # via -r requirements/requirements.txt
-traitlets==4.3.3
+traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -43,7 +43,7 @@ lazy-object-proxy==1.6.0
     # via astroid
 mccabe==0.6.1
     # via pylint
-packaging==20.7
+packaging==20.9
     # via
     #   -r requirements/tests.txt
     #   pytest
@@ -65,7 +65,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/tests.txt
     #   packaging
-pytest==6.2.3
+pytest==6.2.4
     # via -r requirements/tests.txt
 pytz==2020.1
     # via

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,27 +6,27 @@
 #
 amqp==2.6.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   kombu
 attrs==20.3.0
     # via pytest
 billiard==3.6.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 celery==4.4.7
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 coverage==5.5
-    # via -r tests.in
+    # via -r requirements/tests.in
 h-matchers==1.2.11
-    # via -r tests.in
+    # via -r requirements/tests.in
 iniconfig==1.1.1
     # via pytest
 kombu==4.6.11
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
-packaging==20.7
+packaging==20.9
     # via pytest
 pluggy==0.13.1
     # via pytest
@@ -34,18 +34,18 @@ py==1.10.0
     # via pytest
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.3
-    # via -r tests.in
+pytest==6.2.4
+    # via -r requirements/tests.in
 pytz==2020.1
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   celery
 supervisor==4.2.2
-    # via -r requirements.txt
+    # via -r requirements/requirements.txt
 toml==0.10.2
     # via pytest
 vine==1.3.0
     # via
-    #   -r requirements.txt
+    #   -r requirements/requirements.txt
     #   amqp
     #   celery

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,10 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-  tox-pip-extensions
+  tox-pip-sync
   tox-pyenv
   tox-envfile
   tox-run-command
-tox_pip_extensions_ext_venv_update = true
 tox_pyenv_fallback = false
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,6 @@ passenv =
     dev: DEBUG
     dev: DISABLE_H_BEAT
 deps =
-    dev: -e .
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt
     {format,checkformatting}: -r requirements/format.txt


### PR DESCRIPTION
For: https://github.com/hypothesis/tox-pip-sync/issues/11

This also recompiles the dependencies afterward using the technique I've been using on the projects done later in case any changes are found. 

This process is to:

 * `rm requirements/*.txt`
 * `git checkout/requirements.txt` - To preserve the set in live
* `hdev requirements`

This also removed an unnecessary `-e .` which just slows things down.