### PR TITLE
Add dependabot monitoring of docker images (patch versions only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
     versions:
     - ">= 5.0.a"
     - "< 5.1"
+
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+  ignore:
+    # Allow only patch updates for docker images automatically
+    - update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,6 @@ updates:
   schedule:
     interval: daily
   ignore:
-    # Allow only patch updates for docker images automatically
-    - update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    # Only send PRs for patch versions of Python images
+    - dependency-name: "python"
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,6 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: celery
-    versions:
-    - ">= 5.0.a"
-    - "< 5.1"
 
 - package-ecosystem: docker
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,6 @@ updates:
   schedule:
     interval: daily
   ignore:
-    # Only send PRs for patch versions of Python images
+    # Only send PRs for patch versions of Python.
     - dependency-name: "python"
       update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
For: https://github.com/hypothesis/product-backlog/issues/1209

I don't know there's a way to test this without merging it. If we merge it and dependabot works as expected we should get a PR for: `3.8.10-alpine3.14` depending on how/if dependabot handles `10-alpine3.1.4` as a patch number. (See https://hub.docker.com/_/python)

For details of the format see: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore

Also side note, Pycharm is a total dude and has auto complete and schema checking for the dependbot YAML config file, which I was not expecting.

