### PR TITLE
Declare the "celery" exchange as non-durable

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -43,6 +43,7 @@ disable=
     line-too-long,
 
     too-few-public-methods,
+    duplicate-code,
 
 good-names=
     # PyLint's default good names.

--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from os import environ
 
 from celery import Celery
+from kombu import Exchange, Queue
 
 
 def asbool(value):
@@ -22,6 +23,14 @@ if asbool(environ.get("DISABLE_H_BEAT")):  # pragma: nocover
 
 celery = Celery("h")
 celery.conf.update(
+    task_queues=[
+        Queue(
+            "celery",
+            durable=False,
+            routing_key="celery",
+            exchange=Exchange("celery", type="direct", durable=False),
+        )
+    ],
     beat_schedule_filename="h-celerybeat-schedule",
     beat_schedule={
         "purge-deleted-annotations": {


### PR DESCRIPTION
Fixes https://github.com/hypothesis/h-periodic/issues/118

AMQP is raising a `inequivalent arg 'durable' for exchange 'celery' in
vhost 'h': received 'true' but current is 'false'` meaning that the
`'celery'` exchange in CloudAMQP is set to `durable=False` (which is
correct) but h-periodic is trying to declare the exchange as
`durable=True` (which is wrong).

The fix is to change h-periodic to declare the exchange as
`durable=False`. This should make the errors go away.

There shouldn't be any functional change other than the error going
away. The error doesn't actually seem to mean that anything is broken,
it just seems to be warning.

We already do this for Checkmate:

https://github.com/hypothesis/h-periodic/blob/4de61bdd085eee923023a755eb2cca2385109ac9/h_periodic/checkmate_beat.py#L10-L18

We actually want the RabbitMQ queues, exchanges, etc used by h-periodic
to be non-durable. We don't need them to be durable for periodic tasks.
The way that periodic tasks work is that h-periodic constantly runs a
Celery beat process that adds one instance of each task to the queue
every minute (or whatever the time period is, according to the schedules
in the `h_periodic/*_beat.py` files). The task immediately gets consumed
by a worker. A minute later the beat process emits another instance of
the task. And so on.

So there's only ever one instance of each task on the queue at the same
time. Losing the contents of the queue (e.g. in a RabbitMQ crash) would
be no loss: when RabbitMQ comes back up the beat process will just
enqueue the next instance of each periodic task.

In other words h-periodic isn't really using RabbitMQ as a "queue" at
all in the normal sense of the word, it's just using it as a way to
schedule periodic tasks.

Additionally, we actively _don't want_ the queue to be durable. If
RabbitMQ goes down for a time we don't want it to come back up and the
workers to then start executing old instances of tasks. We just want
h-periodic to enqueue the _next_ instance of each periodic task and for
the workers to execute that. For example we don't want multiple workers
to be executing different instances of the same task at once.