### PR TITLE
Reduce the annotation reindexing rate to 1000/m

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -53,7 +53,7 @@ celery.conf.update(
             "options": {"expires": 30},
             "task": "h.tasks.indexer.sync_annotations",
             "schedule": timedelta(minutes=1),
-            "kwargs": {"limit": 2500},
+            "kwargs": {"limit": 1000},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
The reindexing task seems to be over-taxing our Elasticsearch index:

https://hypothes-is.slack.com/archives/C074BUPEG/p1634120648017100

Try reducing the annotation reindexing rate to fix this.