### PR TITLE
Further reduce the annotation reindexing rate

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -53,7 +53,7 @@ celery.conf.update(
             "options": {"expires": 30},
             "task": "h.tasks.indexer.sync_annotations",
             "schedule": timedelta(minutes=1),
-            "kwargs": {"limit": 1000},
+            "kwargs": {"limit": 400},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
We're still seeing timeouts from Elasticsearch even when trying to bulk index only 1000 annotations at a time. Reduce it to 400 to see if that clears it. I don't think we can afford to go much lower than this or the reindexing task will be in danger of being unable to keep up with normal traffic (which regularly spikes up to around 200 new annotations per minute).