### PR TITLE
Add DISABLE_CHECKMATE_BEAT envvar

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,4 +52,5 @@ linting, code formatting, etc.
 | `H_BROKER_URL`         | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
 | `CHECKMATE_BROKER_URL` | The `checkmate` AMPQ broker | `amqp://user:password@rabbit.example.com:5673//` |
 | `DISABLE_H_BEAT` | Whether to disable the `h_beat` process | `true` to disable the `h_beat` process, `false` to leave it enabled. Defaults to `false` (leave it enabled) |
+| `DISABLE_CHECKMATE_BEAT` | Whether to disable the `checkmate_beat` process | `true` to disable the `checkmate_beat` process, `false` to leave it enabled. Defaults to `false` (leave it enabled) |
 

--- a/h_periodic/_util.py
+++ b/h_periodic/_util.py
@@ -1,0 +1,3 @@
+def asbool(value):
+    """Return True if value is any of "t", "true", "y", etc (case-insensitive)."""
+    return str(value).strip().lower() in ("t", "true", "y", "yes", "on", "1")

--- a/h_periodic/checkmate_beat.py
+++ b/h_periodic/checkmate_beat.py
@@ -1,9 +1,18 @@
 """Celery beat scheduler process configuration."""
+import sys
 from datetime import timedelta
+from os import environ
 
 from celery import Celery
 from celery.schedules import crontab
 from kombu import Exchange, Queue
+
+from h_periodic._util import asbool
+
+if asbool(environ.get("DISABLE_CHECKMATE_BEAT")):  # pragma: nocover
+    print("checkmate_beat disabled by DISABLE_CHECKMATE_BEAT environment variable")
+    sys.exit()
+
 
 celery = Celery("checkmate")
 celery.conf.update(

--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -6,11 +6,7 @@ from os import environ
 
 from celery import Celery
 
-
-def asbool(value):
-    """Return True if value is any of "t", "true", "y", etc (case-insensitive)."""
-    return str(value).strip().lower() in ("t", "true", "y", "yes", "on", "1")
-
+from h_periodic._util import asbool
 
 # We don't want periodic tasks for h-qa because h-qa and h-prod share the same
 # database and search index.

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ passenv =
     EXTRA_DEPS
     {tests,functests}: PYTEST_ADDOPTS
     dev: DEBUG
-    dev: DISABLE_H_BEAT
+    dev: DISABLE_*_BEAT
 deps =
     dev: -r requirements/dev.txt
     tests: -r requirements/tests.txt


### PR DESCRIPTION
This will enable us to disable the Checkmate beat for Canada in the same way as we already disable the h beat for QA:

https://github.com/hypothesis/h-periodic/blob/bbe78dcfc358113d2f617092df09199791fe6089/h_periodic/h_beat.py#L19-L21

Fixes https://github.com/hypothesis/h-periodic/issues/114