### PR TITLE
Replicate the tox-pip-sync removal experiment from `h`

### DIFF
--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -1,0 +1,1 @@
+format.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@ envlist = tests
 skipsdist = true
 minversion = 3.16.1
 requires =
-  tox-pip-sync
   tox-pyenv
   tox-envfile
   tox-run-command
@@ -14,17 +13,11 @@ parallel_show_output = true
 skip_install = true
 passenv =
     HOME
-    EXTRA_DEPS
     {tests,functests}: PYTEST_ADDOPTS
     dev: DEBUG
     dev: DISABLE_*_BEAT
 deps =
-    dev: -r requirements/dev.txt
-    tests: -r requirements/tests.txt
-    coverage: -r requirements/coverage.txt
-    {format,checkformatting}: -r requirements/format.txt
-    lint: -r requirements/lint.txt
-    {env:EXTRA_DEPS:}
+    pip-tools
 depends =
     coverage: tests
 setenv =
@@ -32,6 +25,13 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     H_BROKER_URL = amqp://guest:guest@localhost:5672//
     CHECKMATE_BROKER_URL = amqp://guest:guest@localhost:5673//
+whitelist_externals =
+    true
+# This is the command `true` not a value. This is here to disable tox's built
+# in listing of the environments. Which is pointless and slows us down
+list_dependencies = true
+commands_pre =
+    pip-sync requirements/{env:TOX_ENV_NAME}.txt --pip-args '--disable-pip-version-check'
 commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     lint: pylint h_periodic


### PR DESCRIPTION
Some work was done to test the effects of removing `tox-pip-sync` from our tox workflow in `h`. Here:

* https://github.com/hypothesis/h/pull/7475

But `h` is one of the slowest performing apps where any changes are the most likely to be swallowed up by the main time taken to run the actions.

H-periodic offers a much better test bed to show this work in a more honest light as the operations here are much faster and so the overheads are more relevant.

## Results

| Action | 1st Run? | `tox-pip-sync` | This PR | Diff | % |
|----------|--------------|-------------------|-------------|------|----|
| `make format sure` | Yes | 79.0s | 52.3s | +25.7s | 66%
| `make format sure` | No | 13.3s | 18.5s | -5.2s | 139%
| `make format` | Yes | 15.2s | 10.3s | 4.9s | 58%
| `make format` | No | 1.4s | 2.4s | -1.0s | 171%

The general pattern here is that `tox-pip-sync` is quite a bit slower on the first run, and then faster on subsequent runs than this solution. It's particularly relevant on shorter running commands.

### Conclusions?

If we could address this speed difference for repeat runs (a suggestion was made for `pip-sync-faster` which uses hashes to avoid rework) then we could have a best of all worlds on our hands here.

I think there's a strong argument to be made that the simplicity is worth the trade off in speed regardless, however the short tasks are tasks we run most frequently and cause frustration.

It might be worth running this for some time on a project we use a lot (like `lms`) to iron out any bugs before we do a lot of work to roll this out everywhere.

### Follow up

A `tox-no-listing` plugin would be simple, and might be faster than the `true` solution. This might be worth investigating to find out, and could probably be achieved by butchering `tox-pip-sync` locally to find out.

A caching `pip-sync` might be where the real gains are. An investigation into how this would work might be a good idea. This also fits well with our direction of generally applicable loosely coupled tools. However a lot of the complexity around calculating the hash would probably come in here. We would have the benefit of not trying to solve that problem in a `tox` plugin context however.