### PR TITLE
New celery beat for LMS tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,7 @@
 *.pyc
 .coverage
 .coverage.*
-h-celerybeat-schedule
-h-celerybeat-schedule.*
-h-celerybeat.pid
-checkmate-celerybeat-schedule
-checkmate-celerybeat-schedule.*
-checkmate-celerybeat.pid
+*-celerybeat-schedule.*
+*-celerybeat.pid
 supervisord.log
 *.egg-info

--- a/README.markdown
+++ b/README.markdown
@@ -51,6 +51,8 @@ linting, code formatting, etc.
 |----------------------|-------|---------|
 | `H_BROKER_URL`         | The `h` AMPQ broker | `amqp://user:password@rabbit.example.com:5672//` |
 | `CHECKMATE_BROKER_URL` | The `checkmate` AMPQ broker | `amqp://user:password@rabbit.example.com:5673//` |
+| `LMS_BROKER_URL` | The `LMS` AMPQ broker | `amqp://user:password@rabbit.example.com:5674//` |
 | `DISABLE_H_BEAT` | Whether to disable the `h_beat` process | `true` to disable the `h_beat` process, `false` to leave it enabled. Defaults to `false` (leave it enabled) |
 | `DISABLE_CHECKMATE_BEAT` | Whether to disable the `checkmate_beat` process | `true` to disable the `checkmate_beat` process, `false` to leave it enabled. Defaults to `false` (leave it enabled) |
 
+| `DISABLE_LMS_BEAT` | Whether to disable the `lms_beat` process | `true` to disable, `false` to leave it enabled. Defaults to `false` (leave it enabled) |

--- a/conf/supervisord-dev.conf
+++ b/conf/supervisord-dev.conf
@@ -17,6 +17,14 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:lms-beat]
+command=celery -b %(ENV_LMS_BROKER_URL)s -A h_periodic.lms_beat beat --pidfile=lms-celerybeat.pid --loglevel INFO
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
+
 [eventlistener:logger]
 command=bin/logger --dev
 buffer_size=100

--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -18,6 +18,13 @@ stderr_events_enabled=true
 stopsignal = KILL
 stopasgroup = true
 
+[program:lms-beat]
+command=celery -b %(ENV_LMS_BROKER_URL)s -A h_periodic.lms_beat beat --pidfile=lms-celerybeat.pid --loglevel INFO
+stdout_events_enabled=true
+stderr_events_enabled=true
+stopsignal = KILL
+stopasgroup = true
+
 [eventlistener:logger]
 command=bin/logger
 buffer_size=100

--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -1,0 +1,37 @@
+"""Celery beat scheduler process configuration."""
+import sys
+from datetime import timedelta
+from os import environ
+
+from celery import Celery
+from kombu import Exchange, Queue
+
+from h_periodic._util import asbool
+
+if asbool(environ.get("DISABLE_LMS_BEAT")):  # pragma: nocover
+    print("lms_beat disabled by DISABLE_LMS_BEAT environment variable")
+    sys.exit()
+
+
+# pylint: disable=duplicate-code
+celery = Celery("lms")
+celery.conf.update(
+    task_queues=[
+        Queue(
+            "celery",
+            # We don't care if the messages are lost if the broker restarts
+            durable=False,
+            routing_key="celery",
+            exchange=Exchange("celery", type="direct", durable=False),
+        ),
+    ],
+    beat_schedule_filename="lms-celerybeat-schedule",
+    beat_schedule={
+        "rotate-rsa-keys": {
+            "options": {"expires": 600},
+            "task": "lms.tasks.rsa_key.rotate_keys",
+            "schedule": timedelta(days=1),
+        },
+    },
+    task_serializer="json",
+)

--- a/tests/unit/h_periodic/lms_beat_test.py
+++ b/tests/unit/h_periodic/lms_beat_test.py
@@ -1,0 +1,4 @@
+# pylint: disable=unused-import
+# This is for some dodgy test coverage
+
+from h_periodic.lms_beat import celery

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ setenv =
     OBJC_DISABLE_INITIALIZE_FORK_SAFETY = YES
     H_BROKER_URL = amqp://guest:guest@localhost:5672//
     CHECKMATE_BROKER_URL = amqp://guest:guest@localhost:5673//
+    LMS_BROKER_URL = amqp://guest:guest@localhost:5674//
 commands =
     dev: {posargs:supervisord -c conf/supervisord-dev.conf}
     lint: pylint h_periodic


### PR DESCRIPTION
Needs https://github.com/hypothesis/lms/pull/4142 merged first


`LMS_BROKER_URL` already set on prod/qa and Canada environments.

# Testing

- Checkout https://github.com/hypothesis/lms/pull/4142 on LMS and `make services dev`
- Change the perodicity of the task here to something like `minutes=1`, `make dev`
- See the executing of the task on LMS's `make dev` logs.