### PR TITLE
Run the LMS rotate keys task more frequently

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -30,7 +30,7 @@ celery.conf.update(
         "rotate-rsa-keys": {
             "options": {"expires": 600},
             "task": "lms.tasks.rsa_key.rotate_keys",
-            "schedule": timedelta(days=1),
+            "schedule": timedelta(hours=1),
         },
     },
     task_serializer="json",


### PR DESCRIPTION
The beat process gets restarted often, more than once a day, so longer
schedules never get the change of running for the first time.

The rotate keys task itself won't be affected by running more often as
it's based on the age of the keys on the DB.



Some logs of a restart:


```

Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:04,592 INFO supervisord started with pid 1
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:05,594 INFO spawned: 'logger' with pid 14
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:05,598 INFO spawned: 'checkmate-beat' with pid 15
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:05,602 INFO spawned: 'h-beat' with pid 16
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:05,605 INFO spawned: 'lms-beat' with pid 17
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:06,628 INFO success: logger entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:06,629 INFO success: checkmate-beat entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:06,629 INFO success: h-beat entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:06,629 INFO success: lms-beat entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 07:56:06,928 INFO exited: h-beat (exit status 0; expected)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 11:43:39,887 WARN received SIGTERM indicating exit request
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 11:43:39,892 INFO waiting for logger, checkmate-beat, lms-beat to die
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 11:43:39,893 INFO stopped: lms-beat (terminated by SIGKILL)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 11:43:40,898 INFO stopped: checkmate-beat (terminated by SIGKILL)
Jun 29 04:43:51 h-periodic-qa_i-013a4a4e17dfd8307 eb-1ea7a0a3ff69-stdouterr.log 2022-06-29 11:43:40,898 INFO stopped: logger (terminated by SIGTERM)
```

