### PR TITLE
Fix GitHub environment names and URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,35 +25,38 @@ jobs:
   qa-us-west-1:
     needs: create-image
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: qa
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: QA
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-periodic
+      elasticbeanstalk_environment: qa
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   prod-us-west-1:
     needs: [create-image, qa-us-west-1]
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: us-west-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production
+      aws_region: us-west-1
+      elasticbeanstalk_application: h-periodic
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit
 
   prod-ca-central-1:
     needs: [create-image, qa-us-west-1]
     name: ${{ github.event.repository.name }}
-    uses: hypothesis/workflows/.github/workflows/eb-update.yml@main
+    uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      Application: ${{ github.event.repository.name }}
-      Environment: prod
-      Region: ca-central-1
-      Operation: deploy
-      Version: ${{ needs.create-image.outputs.docker_tag }}
+      operation: deploy
+      github_environment_name: Production (Canada)
+      aws_region: ca-central-1
+      elasticbeanstalk_application: h-periodic
+      elasticbeanstalk_environment: prod
+      docker_tag: ${{ needs.create-image.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Change from the `eb-update.yml` workflow to the new `deploy.yml` workflow and
use a separately nicely-named GitHub environment with a URL for each Elastic
Beanstalk environment.

Fixes https://github.com/hypothesis/h-periodic/issues/247
