### PR TITLE
Add GitHub environment URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: QA
+      github_environment_url: https://my.papertrailapp.com/groups/22067362/events
       aws_region: us-west-1
       elasticbeanstalk_application: h-periodic
       elasticbeanstalk_environment: qa
@@ -41,6 +42,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production
+      github_environment_url: https://my.papertrailapp.com/groups/22067372/events
       aws_region: us-west-1
       elasticbeanstalk_application: h-periodic
       elasticbeanstalk_environment: prod
@@ -54,6 +56,7 @@ jobs:
     with:
       operation: deploy
       github_environment_name: Production (Canada)
+      github_environment_url: https://my.papertrailapp.com/groups/28315571/events
       aws_region: ca-central-1
       elasticbeanstalk_application: h-periodic
       elasticbeanstalk_environment: prod


### PR DESCRIPTION
Since h-periodic doesn't have a public URL or any other URL to go to in
order to test it, use the URLs of h-periodic's QA, production and Canada
Papertrail groups for the environment URLs. This means you can click on
the environment URL in GitHub and be taken straight to the Papertrail
logs.
