### PR TITLE
Attempt to fix `deploy.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  workflow_call:
 jobs:
   Format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `ci.yml` workflow needs to be callable by other workflows because `deploy.yml` tries to call it.