### PR TITLE
Reduce LMS email digests batch size to 50

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -36,7 +36,7 @@ celery.conf.update(
         "send_instructor_email_digests": {
             "task": "lms.tasks.email_digests.send_instructor_email_digest_tasks",
             "schedule": crontab(hour=5, minute=15),
-            "kwargs": {"batch_size": 1000},
+            "kwargs": {"batch_size": 50},
         },
     },
     task_serializer="json",


### PR DESCRIPTION
The previous value of 1000 was just an arbitrary number chosen by me and I think it's probably too large: it could take the task a long time to send 1000 emails.

In future we may split the actual email sending out into a separate task which sends one email per task instance. If we do that then we may be able to increase the batch size again.