### PR TITLE
Remove unnecessary exchange and queue settings

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -5,7 +5,6 @@ from os import environ
 
 from celery import Celery
 from celery.schedules import crontab
-from kombu import Exchange, Queue
 
 from h_periodic._util import asbool
 
@@ -17,15 +16,6 @@ if asbool(environ.get("DISABLE_LMS_BEAT")):  # pragma: nocover
 # pylint: disable=duplicate-code
 celery = Celery("lms")
 celery.conf.update(
-    task_queues=[
-        Queue(
-            "celery",
-            # We don't care if the messages are lost if the broker restarts
-            durable=False,
-            routing_key="celery",
-            exchange=Exchange("celery", type="direct", durable=False),
-        ),
-    ],
     beat_schedule_filename="lms-celerybeat-schedule",
     beat_schedule={
         "rotate-rsa-keys": {


### PR DESCRIPTION
These are all the default settings except for `durable=False` and we actualy want it to be `durable=True` (the default) so just remove these.
