### PR TITLE
Fix fill pk schedule to run on the intended times

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -55,7 +55,7 @@ celery.conf.update(
         "fill-annotations-pk": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_pk_and_user_id",
-            "schedule": crontab(hour="*,9-12", minute="*/15"),
+            "schedule": crontab(hour="9-12", minute="*/15"),
             "kwargs": {"batch_size": 10000},
         },
         "report-sync-annotations-queue-length": {


### PR DESCRIPTION
The `*` overrides anything that follows.