### PR TITLE
Decrease batch size to measure its impact

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -55,8 +55,8 @@ celery.conf.update(
         "fill-annotations-pk": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_pk_and_user_id",
-            "schedule": crontab(hour="9-12", minute="*/15"),
-            "kwargs": {"batch_size": 10000},
+            "schedule": crontab(hour="9-12", minute="*/10"),
+            "kwargs": {"batch_size": 5000},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
We have quite a few timeouts today (soft limit, 2 minutes):

https://one.newrelic.com/nr1-core/apm-features/transactions/MTM4NTI4M3xBUE18QVBQTElDQVRJT058MjI2ODg2MzE?account=1385283&duration=604800000&state=fe611650-259d-7fd0-114a-8a0f8f31d672


I'm not sure if the problem is the select side or the update one. Changing the batch size to mesaure its impact here.