### PR TITLE
Increase H pk fill up frequency to run every 5 minutes

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -55,7 +55,7 @@ celery.conf.update(
         "fill-annotations-pk": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_pk_and_user_id",
-            "schedule": crontab(hour="9-12", minute="*/10"),
+            "schedule": crontab(hour="9-12", minute="*/5"),
             "kwargs": {"batch_size": 5000},
         },
         "report-sync-annotations-queue-length": {


### PR DESCRIPTION
Now that the batch size is 5000 run it more frequently


Soft timeout for the task is 2 minutes, hard limit is 4, so we should be within the limits. In any case there's no issue of running more than one of these at the same time if it come to that.