### PR TITLE
Decrease batch size for the H.annotation pk fill up task

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -56,7 +56,7 @@ celery.conf.update(
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_pk_and_user_id",
             "schedule": crontab(hour="4-12", minute="*/5"),
-            "kwargs": {"batch_size": 5000},
+            "kwargs": {"batch_size": 1000},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
We've been seeing a number of timeouts for this tasks. Reducing the number drastically to try to get the number of failed task to 0.


Task monitoring: https://one.newrelic.com/nr1-core/apm-features/transactions/MTM4NTI4M3xBUE18QVBQTElDQVRJT058MjI2ODg2MzE?account=1385283&duration=604800000&state=fe611650-259d-7fd0-114a-8a0f8f31d672