### PR TITLE
Reduce the `batch_size` of `send_instructor_email_digests`

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -26,7 +26,7 @@ celery.conf.update(
         "send_instructor_email_digests": {
             "task": "lms.tasks.email_digests.send_instructor_email_digest_tasks",
             "schedule": crontab(hour=7, minute=15),
-            "kwargs": {"batch_size": 50},
+            "kwargs": {"batch_size": 25},
         },
         "delete_expired_task_done_rows": {
             "task": "lms.tasks.task_done.delete_expired_rows",


### PR DESCRIPTION
Reduce the `batch_size` of the `send_instructor_email_digests` tasks from `50` to `25`.

I'm hoping this will reduce the time taken by the h DB queries that this task triggers and prevent the timeouts that we've been seeing.

This will also double the number of task runs that it takes to get through all the users but I think that should be okay. It should not increase the throughput of the task or increase the load on the DB because the Celery task is rate-limited. So instead I think it will take twice as long to process all the users, which should be acceptable.

Slack thread: https://hypothes-is.slack.com/archives/C0LUWQQJJ/p1695204743405739?thread_ts=1695029990.159129&cid=C0LUWQQJJ