### PR TITLE
Add task to fill the AnnotationSlim table

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from os import environ
 
 from celery import Celery
+from celery.schedules import crontab
 
 from h_periodic._util import asbool
 
@@ -50,6 +51,12 @@ celery.conf.update(
             "task": "h.tasks.indexer.sync_annotations",
             "schedule": timedelta(minutes=1),
             "kwargs": {"limit": 400},
+        },
+        "fill-annotation-slim": {
+            "options": {"expires": 30},
+            "task": "h.tasks.annotations.fill_annotation_slim",
+            "schedule": crontab(hour="4", minute="*/10"),
+            "kwargs": {"batch_size": 1000},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
4AM UTC seem to be the lowest activity period now, before the report refresh and the backup.

Starting with a small batch size.