### PR TITLE
Run the fill annotation task every 4 minutes

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -55,7 +55,7 @@ celery.conf.update(
         "fill-annotation-slim": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_annotation_slim",
-            "schedule": crontab(hour="9-13", minute="*/15"),
+            "schedule": crontab(hour="9-13", minute="*/4"),
             "kwargs": {"batch_size": 1000},
         },
         "report-sync-annotations-queue-length": {


### PR DESCRIPTION
Timeout on the celery task is 2 minutes. One run every 4 should not cause any issues in case one fails.