### PR TITLE
Daily start of the fill annotation with a smaller batch size

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -52,11 +52,17 @@ celery.conf.update(
             "schedule": timedelta(minutes=1),
             "kwargs": {"limit": 400},
         },
+        "fill-annotation-slim-first-batch": {
+            "options": {"expires": 30},
+            "task": "h.tasks.annotations.fill_annotation_slim",
+            "schedule": crontab(hour="8", minute="*/3"),
+            "kwargs": {"batch_size": 500},
+        },
         "fill-annotation-slim": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_annotation_slim",
-            "schedule": crontab(hour="9-13", minute="*/4"),
-            "kwargs": {"batch_size": 1000},
+            "schedule": crontab(hour="9-13", minute="*/3"),
+            "kwargs": {"batch_size": 1500},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
Start the day with a smaller batch size and switch to a bigger one after 1 hour.

Run the task every 3 minutes instead of 4.