### PR TITLE
Further increase fill up task speed

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -61,8 +61,8 @@ celery.conf.update(
         "fill-annotation-slim": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.fill_annotation_slim",
-            "schedule": crontab(hour="8-14", minute="*/3"),
-            "kwargs": {"batch_size": 1500},
+            "schedule": crontab(hour="8-15", minute="*/2"),
+            "kwargs": {"batch_size": 3000},
         },
         "report-sync-annotations-queue-length": {
             "options": {"expires": 30},


### PR DESCRIPTION
After the change in the query the behaviour regarding the first batch seems to still be true so we are keeping the smaller first batches in the morning.

After that  the task seems to finish much faster so we are extending the period when the task runs, make it more frequent and with a bigger batch.

![Screenshot from 2023-11-14 09-34-33](https://github.com/hypothesis/h-periodic/assets/1433832/56403d82-ee01-468f-8147-614b5005d1c5)
