### PR TITLE
Decrease `send_instructor_email_digest_tasks()` batch size

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -26,7 +26,7 @@ celery.conf.update(
         "send_instructor_email_digests": {
             "task": "lms.tasks.email_digests.send_instructor_email_digest_tasks",
             "schedule": crontab(hour=7, minute=15),
-            "kwargs": {"batch_size": 25},
+            "kwargs": {"batch_size": 10},
         },
         "delete_expired_task_done_rows": {
             "task": "lms.tasks.task_done.delete_expired_rows",


### PR DESCRIPTION
Decrease the `batch_size` of the `send_instructor_email_digest_tasks()` Celery task.

This is because I want to try decreasing the task's `batch_size` and correspondingly increasing its `rate_limit` (see https://github.com/hypothesis/lms/pull/5827) to see what effect that has on performance, with an eye towards potentially removing the batching feature altogether in order to simplify adding future features to this code.
