### PR TITLE
Decrease `send_instructor_email_digests` batch size again

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -26,7 +26,7 @@ celery.conf.update(
         "send_instructor_email_digests": {
             "task": "lms.tasks.email_digests.send_instructor_email_digest_tasks",
             "schedule": crontab(hour=7, minute=15),
-            "kwargs": {"batch_size": 10},
+            "kwargs": {"batch_size": 1},
         },
         "delete_expired_task_done_rows": {
             "task": "lms.tasks.task_done.delete_expired_rows",


### PR DESCRIPTION
Decrease the batch size of the `send_instructor_email_digests()` Celery
task again, this time decreasing it 10x from `10` to `1`.

This is to enable us to see whether we could get away with removing the
batching feature. We'll attempt to maintain the speed at which emails
are generated at about the same rate by simultaneously increasing the
task's rate limit, see: https://github.com/hypothesis/lms/pull/5841

Slack thread: https://hypothes-is.slack.com/archives/C1MA4E9B9/p1700130444868909?thread_ts=1699980253.387059&cid=C1MA4E9B9
