### PR TITLE
Upgrade python dependencies

### DIFF
--- a/requirements/checkformatting.txt
+++ b/requirements/checkformatting.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile --allow-unsafe requirements/checkformatting.in
 #
-black==23.11.0
+black==23.12.1
     # via -r requirements/checkformatting.in
-build==0.9.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==6.6.0
-    # via pip-sync-faster
-isort==5.12.0
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
+isort==5.13.2
     # via -r requirements/checkformatting.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.10.2
+pathspec==0.12.1
     # via black
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/checkformatting.in
 pip-tools==7.3.0
     # via
     #   -r requirements/checkformatting.in
     #   pip-sync-faster
-platformdirs==2.5.4
+platformdirs==4.1.0
     # via black
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
-typing-extensions==4.4.0
+    #   pyproject-hooks
+typing-extensions==4.9.0
     # via black
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/coverage.txt
+++ b/requirements/coverage.txt
@@ -4,19 +4,17 @@
 #
 #    pip-compile --allow-unsafe requirements/coverage.in
 #
-build==0.9.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via pip-tools
-coverage[toml]==7.3.2
+coverage[toml]==7.4.0
+    # via -r requirements/coverage.in
+importlib-metadata==7.0.1
     # via
-    #   -r requirements/coverage.in
-    #   coverage
-importlib-metadata==6.6.0
-    # via pip-sync-faster
-packaging==21.3
-    # via build
-pep517==0.13.0
+    #   build
+    #   pip-sync-faster
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/coverage.in
@@ -24,21 +22,21 @@ pip-tools==7.3.0
     # via
     #   -r requirements/coverage.in
     #   pip-sync-faster
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
-wheel==0.38.4
+    #   pyproject-hooks
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --allow-unsafe requirements/dev.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
-asttokens==2.1.0
+asttokens==2.4.1
     # via stack-data
 backcall==0.2.0
     # via ipython
@@ -22,15 +22,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.9.0
+build==1.0.3
     # via pip-tools
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -46,23 +46,25 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
 decorator==5.1.1
     # via ipython
-executing==1.2.0
+executing==2.0.1
     # via stack-data
 factory-boy==3.3.0
     # via -r requirements/dev.in
-faker==15.3.2
+faker==22.0.0
     # via factory-boy
-importlib-metadata==6.6.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 ipython==8.12.3
     # via -r requirements/dev.in
-jedi==0.18.1
+jedi==0.19.1
     # via ipython
 kombu==5.3.4
     # via
@@ -70,13 +72,11 @@ kombu==5.3.4
     #   celery
 matplotlib-inline==0.1.6
     # via ipython
-packaging==21.3
+packaging==23.2
     # via build
 parso==0.8.3
     # via jedi
-pep517==0.13.0
-    # via build
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
@@ -86,7 +86,7 @@ pip-tools==7.3.0
     # via
     #   -r requirements/dev.in
     #   pip-sync-faster
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
@@ -95,10 +95,10 @@ ptyprocess==0.7.0
     # via pexpect
 pure-eval==0.2.2
     # via stack-data
-pygments==2.15.0
+pygments==2.17.2
     # via ipython
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 python-dateutil==2.8.2
     # via
     #   -r requirements/prod.txt
@@ -110,9 +110,8 @@ six==1.16.0
     # via
     #   -r requirements/prod.txt
     #   asttokens
-    #   click-repl
     #   python-dateutil
-stack-data==0.6.1
+stack-data==0.6.3
     # via ipython
 supervisor==4.2.5
     # via
@@ -121,23 +120,24 @@ supervisor==4.2.5
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
-traitlets==5.5.0
+    #   pyproject-hooks
+traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.6.3
+typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
+    #   faker
     #   ipython
     #   kombu
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
@@ -147,19 +147,19 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
     #   pip-tools

--- a/requirements/format.txt
+++ b/requirements/format.txt
@@ -4,51 +4,53 @@
 #
 #    pip-compile --allow-unsafe requirements/format.in
 #
-black==23.11.0
+black==23.12.1
     # via -r requirements/format.in
-build==0.9.0
+build==1.0.3
     # via pip-tools
-click==8.1.3
+click==8.1.7
     # via
     #   black
     #   pip-tools
-importlib-metadata==6.6.0
-    # via pip-sync-faster
-isort==5.12.0
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
+isort==5.13.2
     # via -r requirements/format.in
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
-packaging==23.0
+packaging==23.2
     # via
     #   black
     #   build
-pathspec==0.10.2
+pathspec==0.12.1
     # via black
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/format.in
 pip-tools==7.3.0
     # via
     #   -r requirements/format.in
     #   pip-sync-faster
-platformdirs==2.5.4
+platformdirs==4.1.0
     # via black
+pyproject-hooks==1.0.0
+    # via build
 tomli==2.0.1
     # via
     #   black
     #   build
-    #   pep517
     #   pip-tools
-typing-extensions==4.4.0
+    #   pyproject-hooks
+typing-extensions==4.9.0
     # via black
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/functests.txt
+++ b/requirements/functests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe requirements/functests.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
@@ -18,15 +18,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.9.0
+build==1.0.3
     # via pip-tools
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -42,52 +42,52 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-exceptiongroup==1.0.4
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via
     #   -r requirements/functests.in
     #   pytest-factoryboy
-faker==15.3.2
+faker==22.0.0
     # via factory-boy
 h-matchers==1.2.15
     # via -r requirements/functests.in
 httpretty==1.1.4
     # via -r requirements/functests.in
-importlib-metadata==6.6.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 inflection==0.5.1
     # via pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 kombu==5.3.4
     # via
     #   -r requirements/prod.txt
     #   celery
-packaging==21.3
+packaging==23.2
     # via
     #   build
     #   pytest
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/functests.in
 pip-tools==7.3.0
     # via
     #   -r requirements/functests.in
     #   pip-sync-faster
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 pytest==7.4.4
     # via
     #   -r requirements/functests.in
@@ -104,27 +104,27 @@ sentry-sdk==1.39.1
 six==1.16.0
     # via
     #   -r requirements/prod.txt
-    #   click-repl
     #   python-dateutil
 supervisor==4.2.5
     # via -r requirements/prod.txt
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-typing-extensions==4.6.3
+typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
+    #   faker
     #   kombu
     #   pytest-factoryboy
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
@@ -134,19 +134,19 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
     #   pip-tools

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,12 +4,12 @@
 #
 #    pip-compile --allow-unsafe requirements/lint.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   kombu
-astroid==3.0.1
+astroid==3.0.2
     # via pylint
 backports-zoneinfo[tzdata]==0.2.1
     # via
@@ -23,7 +23,7 @@ billiard==4.2.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-build==0.9.0
+build==1.0.3
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -32,12 +32,12 @@ celery==5.3.6
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   sentry-sdk
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -56,19 +56,19 @@ click-plugins==1.1.1
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   celery
-coverage[toml]==7.3.1
+coverage[toml]==7.4.0
     # via
     #   -r requirements/tests.txt
     #   coverage
     #   pytest-cov
-dill==0.3.6
+dill==0.3.7
     # via pylint
-exceptiongroup==1.0.4
+exceptiongroup==1.2.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -78,7 +78,7 @@ factory-boy==3.3.0
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest-factoryboy
-faker==15.3.2
+faker==22.0.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -93,22 +93,23 @@ httpretty==1.1.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-importlib-metadata==6.6.0
+importlib-metadata==7.0.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
+    #   build
     #   pip-sync-faster
 inflection==0.5.1
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
-isort==5.12.0
+isort==5.13.2
     # via pylint
 kombu==5.3.4
     # via
@@ -117,17 +118,12 @@ kombu==5.3.4
     #   celery
 mccabe==0.7.0
     # via pylint
-packaging==21.3
+packaging==23.2
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   build
     #   pytest
-pep517==0.13.0
-    # via
-    #   -r requirements/functests.txt
-    #   -r requirements/tests.txt
-    #   build
 pip-sync-faster==0.0.3
     # via
     #   -r requirements/functests.txt
@@ -139,14 +135,14 @@ pip-tools==7.3.0
     #   -r requirements/lint.in
     #   -r requirements/tests.txt
     #   pip-sync-faster
-platformdirs==2.5.4
+platformdirs==4.1.0
     # via pylint
-pluggy==1.0.0
+pluggy==1.3.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pytest
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -157,11 +153,11 @@ pydocstyle==6.3.0
     # via -r requirements/lint.in
 pylint==3.0.3
     # via -r requirements/lint.in
-pyparsing==3.0.9
+pyproject-hooks==1.0.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   packaging
+    #   build
 pytest==7.4.4
     # via
     #   -r requirements/functests.txt
@@ -189,7 +185,6 @@ six==1.16.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
-    #   click-repl
     #   python-dateutil
 snowballstemmer==2.2.0
     # via pydocstyle
@@ -205,27 +200,28 @@ tomli==2.0.1
     #   -r requirements/tests.txt
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
     #   pylint
+    #   pyproject-hooks
     #   pytest
-tomlkit==0.11.6
+tomlkit==0.12.3
     # via pylint
-typing-extensions==4.6.3
+typing-extensions==4.9.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   astroid
+    #   faker
     #   kombu
     #   pylint
     #   pytest-factoryboy
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
@@ -237,29 +233,29 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   prompt-toolkit
-wheel==0.38.4
+wheel==0.42.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt
     #   pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via
     #   -r requirements/functests.txt
     #   -r requirements/tests.txt

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe requirements/prod.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 backports-zoneinfo[tzdata]==0.2.1
     # via
@@ -14,9 +14,9 @@ billiard==4.2.0
     # via celery
 celery==5.3.6
     # via -r requirements/prod.in
-certifi==2023.7.22
+certifi==2023.11.17
     # via sentry-sdk
-click==8.1.3
+click==8.1.7
     # via
     #   celery
     #   click-didyoumean
@@ -26,38 +26,36 @@ click-didyoumean==0.3.0
     # via celery
 click-plugins==1.1.1
     # via celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via celery
 kombu==5.3.4
     # via celery
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.43
     # via click-repl
 python-dateutil==2.8.2
     # via celery
 sentry-sdk==1.39.1
     # via -r requirements/prod.in
 six==1.16.0
-    # via
-    #   click-repl
-    #   python-dateutil
+    # via python-dateutil
 supervisor==4.2.5
     # via -r requirements/prod.in
-typing-extensions==4.6.3
+typing-extensions==4.9.0
     # via kombu
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via sentry-sdk
 vine==5.1.0
     # via
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==65.5.1
+setuptools==69.0.3
     # via supervisor

--- a/requirements/template.txt
+++ b/requirements/template.txt
@@ -4,39 +4,39 @@
 #
 #    pip-compile --allow-unsafe requirements/template.in
 #
-arrow==1.2.3
+arrow==1.3.0
     # via cookiecutter
 binaryornot==0.4.4
     # via cookiecutter
-build==0.9.0
+build==1.0.3
     # via pip-tools
-certifi==2023.7.22
+certifi==2023.11.17
     # via requests
-chardet==5.0.0
+chardet==5.2.0
     # via binaryornot
-charset-normalizer==2.1.1
+charset-normalizer==3.3.2
     # via requests
-click==8.1.3
+click==8.1.7
     # via
     #   cookiecutter
     #   pip-tools
 cookiecutter==2.5.0
     # via -r requirements/template.in
-idna==3.4
+idna==3.6
     # via requests
-importlib-metadata==6.6.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 jinja2==3.1.2
     # via cookiecutter
 markdown-it-py==3.0.0
     # via rich
-markupsafe==2.1.1
+markupsafe==2.1.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-packaging==21.3
-    # via build
-pep517==0.13.0
+packaging==23.2
     # via build
 pip-sync-faster==0.0.3
     # via -r requirements/template.in
@@ -44,19 +44,19 @@ pip-tools==7.3.0
     # via
     #   -r requirements/template.in
     #   pip-sync-faster
-pygments==2.16.1
+pygments==2.17.2
     # via rich
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 python-dateutil==2.8.2
     # via arrow
-python-slugify==6.1.2
+python-slugify==8.0.1
     # via cookiecutter
-pyyaml==6.0
+pyyaml==6.0.1
     # via cookiecutter
 requests==2.31.0
     # via cookiecutter
-rich==13.5.2
+rich==13.7.0
     # via cookiecutter
 six==1.16.0
     # via python-dateutil
@@ -65,19 +65,21 @@ text-unidecode==1.3
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
-typing-extensions==4.7.1
+    #   pyproject-hooks
+types-python-dateutil==2.8.19.20240106
+    # via arrow
+typing-extensions==4.9.0
     # via rich
-urllib3==1.26.18
+urllib3==2.1.0
     # via requests
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via pip-tools

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe requirements/tests.in
 #
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/prod.txt
     #   kombu
@@ -18,15 +18,15 @@ billiard==4.2.0
     # via
     #   -r requirements/prod.txt
     #   celery
-build==0.9.0
+build==1.0.3
     # via pip-tools
 celery==5.3.6
     # via -r requirements/prod.txt
-certifi==2023.7.22
+certifi==2023.11.17
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
-click==8.1.3
+click==8.1.7
     # via
     #   -r requirements/prod.txt
     #   celery
@@ -42,21 +42,21 @@ click-plugins==1.1.1
     # via
     #   -r requirements/prod.txt
     #   celery
-click-repl==0.2.0
+click-repl==0.3.0
     # via
     #   -r requirements/prod.txt
     #   celery
-coverage[toml]==7.3.1
+coverage[toml]==7.4.0
     # via
     #   coverage
     #   pytest-cov
-exceptiongroup==1.0.4
+exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via
     #   -r requirements/tests.in
     #   pytest-factoryboy
-faker==15.3.2
+faker==22.0.0
     # via factory-boy
 freezegun==1.4.0
     # via -r requirements/tests.in
@@ -64,36 +64,36 @@ h-matchers==1.2.15
     # via -r requirements/tests.in
 httpretty==1.1.4
     # via -r requirements/tests.in
-importlib-metadata==6.6.0
-    # via pip-sync-faster
+importlib-metadata==7.0.1
+    # via
+    #   build
+    #   pip-sync-faster
 inflection==0.5.1
     # via pytest-factoryboy
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 kombu==5.3.4
     # via
     #   -r requirements/prod.txt
     #   celery
-packaging==21.3
+packaging==23.2
     # via
     #   build
     #   pytest
-pep517==0.13.0
-    # via build
 pip-sync-faster==0.0.3
     # via -r requirements/tests.in
 pip-tools==7.3.0
     # via
     #   -r requirements/tests.in
     #   pip-sync-faster
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
-prompt-toolkit==3.0.32
+prompt-toolkit==3.0.43
     # via
     #   -r requirements/prod.txt
     #   click-repl
-pyparsing==3.0.9
-    # via packaging
+pyproject-hooks==1.0.0
+    # via build
 pytest==7.4.4
     # via
     #   -r requirements/tests.in
@@ -114,7 +114,6 @@ sentry-sdk==1.39.1
 six==1.16.0
     # via
     #   -r requirements/prod.txt
-    #   click-repl
     #   python-dateutil
 supervisor==4.2.5
     # via -r requirements/prod.txt
@@ -122,20 +121,21 @@ tomli==2.0.1
     # via
     #   build
     #   coverage
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
-typing-extensions==4.6.3
+typing-extensions==4.9.0
     # via
     #   -r requirements/prod.txt
+    #   faker
     #   kombu
     #   pytest-factoryboy
-tzdata==2023.3
+tzdata==2023.4
     # via
     #   -r requirements/prod.txt
     #   backports-zoneinfo
     #   celery
-urllib3==1.26.18
+urllib3==2.1.0
     # via
     #   -r requirements/prod.txt
     #   sentry-sdk
@@ -145,19 +145,19 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-wcwidth==0.2.5
+wcwidth==0.2.13
     # via
     #   -r requirements/prod.txt
     #   prompt-toolkit
-wheel==0.38.4
+wheel==0.42.0
     # via pip-tools
-zipp==3.15.0
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.3
+pip==23.3.2
     # via pip-tools
-setuptools==65.5.1
+setuptools==69.0.3
     # via
     #   -r requirements/prod.txt
     #   pip-tools


### PR DESCRIPTION
This is the result of running:

`make requirements --always-make args='--upgrade'`

Non top level dependencies can become outdated as dependabot doesn't send PR for those.

On top of that upgrading single packages with all the existing constraints might make impassible to satisfy all constraints.

This approach makes sure we are up to date with all our dependencies as specified on the .in files but without considering any constraints in the .txt files.