### PR TITLE
Process jobs for filling up the slim table more often

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -54,7 +54,7 @@ celery.conf.update(
         "sync-slim-annotations": {
             "options": {"expires": 30},
             "task": "h.tasks.annotations.sync_annotation_slim",
-            "schedule": timedelta(minutes=5),
+            "schedule": timedelta(minutes=2),
             "kwargs": {"limit": 500},
         },
         "report-sync-annotations-queue-length": {


### PR DESCRIPTION

![image](https://github.com/hypothesis/h-periodic/assets/1433832/d870341f-1314-42dc-8e92-ab70d2e8a5c5)

---

This is based on a different approach.

Jobs are added to the queue in H, using the admin pages and this job process a number of rows each time.

Technically we don't have to make expensive queries to process them, just query annos by ID. We still might hit different bottlenecks as we progress.

