### PR TITLE
Revert "Run purge_deleted_users() every minute"

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -53,7 +53,7 @@ celery.conf.update(
         "purge-deleted-users": {
             "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_deleted_users",
-            "schedule": timedelta(minutes=1),
+            "schedule": timedelta(hours=1),
         },
         "sync-annotations": {
             "options": {"expires": 30},


### PR DESCRIPTION
This reverts commit 92811a26eaa8069cc69e0986485d44e2f7a933b2,
the `purge_deleted_users()` task will now be run hourly again instead of
every minute.
