### PR TITLE
Run some h tasks more frequently

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -23,7 +23,7 @@ celery.conf.update(
         "purge-deleted-annotations": {
             "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_deleted_annotations",
-            "schedule": timedelta(hours=1),
+            "schedule": timedelta(minutes=5),
         },
         "report-num-deleted-annotations": {
             "options": {"expires": 30},
@@ -53,7 +53,7 @@ celery.conf.update(
         "purge-deleted-users": {
             "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_deleted_users",
-            "schedule": timedelta(hours=1),
+            "schedule": timedelta(minutes=5),
         },
         "sync-annotations": {
             "options": {"expires": 30},


### PR DESCRIPTION
Running the `purge-deleted-annotations` and `purge-deleted-users` tasks
only hourly means that it can take quite a while after deleting an
annotation or user before that data is actually deleted from our DB,
especially if there are a lot of annotations or users to be purged so
that we have to wait for the task to run multiple times (so multiple
hours) to get through them all.

Run these two tasks every 5 mins instead.

Looking at these two tasks in New Relic they take only milliseconds to
run, so running them every few minutes shouldn't be a problem.

https://onenr.io/07j9P3z4ARO
https://onenr.io/0VRVdEG01Qa
