### PR TITLE
Temporarily remove the `report_num_deleted_annotations()` task

### DIFF
--- a/h_periodic/h_beat.py
+++ b/h_periodic/h_beat.py
@@ -25,11 +25,6 @@ celery.conf.update(
             "task": "h.tasks.cleanup.purge_deleted_annotations",
             "schedule": timedelta(minutes=5),
         },
-        "report-num-deleted-annotations": {
-            "options": {"expires": 30},
-            "task": "h.tasks.cleanup.report_num_deleted_annotations",
-            "schedule": timedelta(minutes=1),
-        },
         "purge-expired-authtickets": {
             "options": {"expires": 1800},
             "task": "h.tasks.cleanup.purge_expired_auth_tickets",


### PR DESCRIPTION
This is so that I can test New Relic's "lost signal" alert for the num.
deleted annotations metric.

This commit will be reverted after testing.
