### PR TITLE
Schedule more frequently usage reports

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -34,7 +34,7 @@ celery.conf.update(
         },
         "schedule_monthly_deal_report": {
             "task": "lms.tasks.organization.schedule_monthly_deal_report",
-            "schedule": timedelta(hours=1),
+            "schedule": timedelta(minutes=15),
             "kwargs": {"limit": 1, "backfill": 24},
         },
         "delete_expired_task_done_rows": {


### PR DESCRIPTION
While the goal is to run this only at the start of every month a more frequent schedule is useful now for:

- Debugging any issue without long waits
- Start backfilling reports for existing organizations