### PR TITLE
Change parameters for LMS monthly report task

### DIFF
--- a/h_periodic/lms_beat.py
+++ b/h_periodic/lms_beat.py
@@ -35,7 +35,7 @@ celery.conf.update(
         "schedule_monthly_deal_report": {
             "task": "lms.tasks.organization.schedule_monthly_deal_report",
             "schedule": timedelta(minutes=15),
-            "kwargs": {"limit": 1, "backfill": 24},
+            "kwargs": {"limit": 2, "backfill": 2},
         },
         "delete_expired_task_done_rows": {
             "task": "lms.tasks.task_done.delete_expired_rows",


### PR DESCRIPTION
- Limit increased to 2

This will just make the generation faster

- Set backfill to 2

Now we have a few organizations that have completed the backfill going back to the earliest report they'll ever have.

To focus on a different type of metabase report (ie a report that queries the data generated here) it would more useful to have more organizations with reports rather that just a few with all their history.

Setting backfill to 2 will just generate 3 reports per organization (the last one plus two past ones) before moving to the next organization.